### PR TITLE
Add aiGenerated frontmatter field and transparency banner

### DIFF
--- a/components/AIGeneratedBanner.tsx
+++ b/components/AIGeneratedBanner.tsx
@@ -1,0 +1,13 @@
+const AIGeneratedBanner = () => {
+  return (
+    <div className="my-4 rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400">
+      <span className="mr-1.5 inline-block text-gray-400 dark:text-gray-500" aria-hidden="true">
+        &#9432;
+      </span>
+      This post was AI-generated from development pipeline artifacts and reviewed by Tim Yu before
+      publishing.
+    </div>
+  )
+}
+
+export default AIGeneratedBanner

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -91,6 +91,7 @@ export const Blog = defineDocumentType(() => ({
     layout: { type: 'string' },
     bibliography: { type: 'string' },
     canonicalUrl: { type: 'string' },
+    aiGenerated: { type: 'boolean', default: false },
   },
   computedFields: {
     ...computedFields,

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -9,6 +9,7 @@ import Image from '@/components/Image'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
+import AIGeneratedBanner from '@/components/AIGeneratedBanner'
 
 const editUrl = (path) => `${siteMetadata.siteRepo}/blob/main/data/${path}`
 const discussUrl = (path) =>
@@ -30,7 +31,7 @@ interface LayoutProps {
 }
 
 export default function PostLayout({ content, authorDetails, next, prev, children }: LayoutProps) {
-  const { filePath, path, slug, date, title, tags } = content
+  const { filePath, path, slug, date, title, tags, aiGenerated } = content
   const basePath = path.split('/')[0]
 
   return (
@@ -94,7 +95,10 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
               </dd>
             </dl> */}
             <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
-              <div className="prose max-w-none pb-8 pt-10 dark:prose-invert">{children}</div>
+              <div className="prose max-w-none pb-8 pt-10 dark:prose-invert">
+                {aiGenerated && <AIGeneratedBanner />}
+                {children}
+              </div>
               <div className="pb-6 pt-6 text-sm text-gray-700 dark:text-gray-300">
                 {/* <Link href={discussUrl(path)} rel="nofollow">
                   Discuss on Twitter


### PR DESCRIPTION
- Add aiGenerated boolean (default: false) to contentlayer Blog schema
- Create AIGeneratedBanner component with subtle transparency note
- Wire banner into blog post layout, renders only when aiGenerated: true