### PR TITLE
Add draft URL access guard in production

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({
     const authorResults = allAuthors.find((p) => p.slug === author)
     return coreContent(authorResults as Authors)
   })
-  if (!post) {
+  if (!post || (isProduction && post.draft)) {
     return
   }
 


### PR DESCRIPTION
## Summary
- Filter draft posts from `generateStaticParams` in production (no static pages generated)
- Return 404 for direct URL access to draft posts in production
- Guard `generateMetadata` to prevent OG/Twitter metadata leak for drafts
- Drafts remain accessible in dev mode for preview

Closes #3

## Test plan
- [x] All 3 guards in place (generateStaticParams, Page, generateMetadata)
- [x] `isProduction` pattern matches contentlayer.config.ts
- [x] No existing posts affected (none have draft: true)
- [x] Review: 1 fix loop (metadata leak guard added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)