### PR TITLE
Add Tags navigation link

### DIFF
--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -1,9 +1,6 @@
 const headerNavLinks = [
-  // { href: '/', title: 'Home' },
-  // { href: '/blog', title: 'Blog' },
-  // { href: '/tags', title: 'Tags' },
-  // { href: '/projects', title: 'Projects' },
   { href: '/', title: 'Posts' },
+  { href: '/tags', title: 'Tags' },
   { href: '/about', title: 'About' },
 ]
 


### PR DESCRIPTION
## Summary
- Added Tags nav link (`/tags`) for tag-based content discovery
- Removed commented-out template nav links (Home, Blog, Tags, Projects)
- AI posts will be discoverable via the `ai` tag on the Tags page
- Skipped dedicated `/tags/ai` nav link — would 404 until first AI post exists

Closes #4

## Test plan
- [x] Nav links render correctly
- [x] `/tags` route already exists and works
- [x] No 404 risk (unlike dedicated `/tags/ai`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)