### PR TITLE
Add Sveltia CMS for inline blog editing

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,42 @@
+backend:
+  name: github
+  repo: tyu41275/ghostpen
+  branch: main
+
+media_folder: public/static/images
+public_folder: /static/images
+
+collections:
+  - name: blog
+    label: Blog Posts
+    folder: data/blog
+    create: true
+    extension: mdx
+    format: frontmatter
+    fields:
+      - { label: Title, name: title, widget: string }
+      - { label: Publish Date, name: date, widget: datetime, format: 'YYYY-MM-DD', date_format: 'YYYY-MM-DD', time_format: false }
+      - { label: Last Modified, name: lastmod, widget: datetime, format: 'YYYY-MM-DD', date_format: 'YYYY-MM-DD', time_format: false, required: false }
+      - { label: Tags, name: tags, widget: list, default: [] }
+      - { label: Draft, name: draft, widget: boolean, default: false }
+      - { label: AI Generated, name: aiGenerated, widget: boolean, default: false }
+      - { label: Summary, name: summary, widget: text }
+      - { label: Authors, name: authors, widget: list, default: ['default'] }
+      - { label: Images, name: images, widget: list, required: false, default: [] }
+      - { label: Body, name: body, widget: markdown }
+
+  - name: authors
+    label: Authors
+    folder: data/authors
+    create: true
+    extension: mdx
+    format: frontmatter
+    fields:
+      - { label: Name, name: name, widget: string }
+      - { label: Avatar, name: avatar, widget: image, required: false }
+      - { label: Occupation, name: occupation, widget: string, required: false }
+      - { label: Company, name: company, widget: string, required: false }
+      - { label: Email, name: email, widget: string, required: false }
+      - { label: LinkedIn, name: linkedin, widget: string, required: false }
+      - { label: GitHub, name: github, widget: string, required: false }
+      - { label: Body, name: body, widget: markdown }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
+  <title>Content Manager</title>
+</head>
+<body>
+  <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Added Sveltia CMS admin UI at `/admin` (loaded from CDN, zero npm deps)
- GitHub OAuth backend for authentication
- Blog collection maps to contentlayer Blog schema (title, date, tags, draft, aiGenerated, summary, authors, images)
- Authors collection also editable
- `noindex` meta tag keeps admin page out of search engines

**Note:** Requires GitHub OAuth app registration for auth on deployed site. Register at https://github.com/settings/applications/new

Closes #7

## Test plan
- [x] Schema maps to all contentlayer Blog fields
- [x] Field types match (string, boolean, list, datetime)
- [x] Media paths correct (public/static/images)
- [x] No secrets or API keys in config
- [x] CDN URL resolves correctly
- [ ] Functional test on deployed site (requires OAuth app setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)