### PR TITLE
Add Sveltia CMS auth backend URL

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: tyu41275/ghostpen
   branch: main
+  base_url: https://sveltia-cms-auth.tyu41275.workers.dev
 
 media_folder: public/static/images
 public_folder: /static/images


### PR DESCRIPTION
## Summary
- Added `base_url: https://sveltia-cms-auth.tyu41275.workers.dev` to CMS backend config
- Enables GitHub OAuth authentication for Sveltia CMS on the deployed site

## Test plan
- [ ] Navigate to `/admin` on deployed site
- [ ] Click "Login with GitHub"
- [ ] Verify OAuth flow completes and CMS loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)