### PR TITLE
Link AI banner to EcoOrchestra foundation post

### DIFF
--- a/components/AIGeneratedBanner.tsx
+++ b/components/AIGeneratedBanner.tsx
@@ -1,3 +1,5 @@
+import Link from './Link'
+
 const AIGeneratedBanner = () => {
   return (
     <div
@@ -7,8 +9,14 @@ const AIGeneratedBanner = () => {
       <span className="mr-1.5 inline-block text-gray-400 dark:text-gray-500" aria-hidden="true">
         &#9432;
       </span>
-      This post was AI-generated from development pipeline artifacts and reviewed by me before
-      publishing.
+      This post was AI-generated from{' '}
+      <Link
+        href="/blog/2026-03-15-what-is-ecoorchestra"
+        className="underline decoration-gray-400 underline-offset-2 hover:text-gray-800 dark:decoration-gray-500 dark:hover:text-gray-300"
+      >
+        development pipeline artifacts
+      </Link>{' '}
+      and reviewed by me before publishing.
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Updated `AIGeneratedBanner.tsx` to link "development pipeline artifacts" to the EcoOrchestra foundation post at `/blog/2026-03-15-what-is-ecoorchestra`
- Uses the project's `CustomLink` component for internal Next.js routing
- Subtle underline styling in both light and dark modes

Closes #26

## Test plan
- [x] Visual QA via Playwright — light and dark mode screenshots verified
- [x] Code review — Link component usage correct, Tailwind classes appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)