### PR TITLE
docs: add anti-formula rules to the writing style guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ app/                    # Next.js 14 app directory (pages, layouts, API routes)
 data/
   blog/                 # .mdx blog posts (YAML frontmatter + MDX body)
   authors/              # Author profiles (default.mdx = Tim Yu)
-  style-guide.md        # Writing style extracted from existing posts — AI generators MUST follow this
+  style-guide.md        # Writing style extracted from existing posts — AI generators MUST follow this. Read the "Anti-Formula Rules" section as binding over the example lists above it: the "Characteristic phrases" list and the rejection criteria describe RANGE, and a generator optimising against them as a checklist produces six near-identical posts (#67-#75; #74 used 7 of the 8 example catchphrases in the guide's own order, against 0-2 for the human posts). The rules cap catchphrase reuse at two, ban the templated Problem/Investigation/Solution/Conclusion header set, and set the length target from the published corpus.
   siteMetadata.js       # Site-wide config (title, URL, analytics, search, comments)
   projectsData.ts       # Projects page content
   headerNavLinks.ts     # Navigation links

--- a/data/style-guide.md
+++ b/data/style-guide.md
@@ -129,6 +129,37 @@ A generated post MUST be rejected and rewritten if any of these conditions apply
 
 6. **Conclusion recaps the post.** If the conclusion summarizes what was already covered ("In this post, we looked at..."), reject. Conclusions should state a theory, a forward-looking remark, or a brief takeaway.
 
+## Anti-Formula Rules — These Override the Example Lists Above
+
+The "Characteristic phrases" and "Rejection criteria" sections describe RANGE, not a
+checklist. Six consecutive generated drafts (ghostpen #67-#75) satisfied the criteria
+mechanically and read as the same post with the nouns swapped: `#74` used seven of the
+eight example catchphrases, `#75` used six, both in the same order, under the same four
+headers. Tim's own posts use zero to two. So:
+
+1. **Catchphrase ceiling: two per post, maximum.** Use one only where it genuinely
+   fits the moment. `guardrails-vs-velocity` and
+   `building-a-circuit-breaker-across-two-repos` use NONE and are the two strongest
+   posts in the corpus. Never open with "Ok. That's new." as a reflex.
+
+2. **The header set `## The Problem` / `## The Investigation` / `## The Solution` /
+   `## Conclusion` is banned.** It is the narrative arc, not a template. Write headers
+   that name this post's specifics, or use no headers at all — several of the best
+   posts have none.
+
+3. **Vary the opening.** Not every post begins with a one-sentence scene-set followed
+   by a reaction fragment.
+
+4. **Length: 900-1300 words** for an AI-category post. The published corpus runs
+   700-1400. A 550-word post reads as a summary of work, not an account of it.
+
+5. **Two code blocks minimum, showing REAL artifacts** — actual error text, a real
+   config snippet, a genuine diff. Invented pseudo-code (`deploy` / `smoke_test ||
+   file_blocking_issue`) is a tell.
+
+6. **Earn the sign-off.** "Thanks for reading!" belongs on a post that taught
+   something, not on every post by default.
+
 ## AI Category Adaptations
 
 Posts in the AI category differ from Sitecore posts in these ways:


### PR DESCRIPTION
Six consecutive AI-generated drafts (#67-#75) satisfied the style guide's rejection criteria mechanically and read as the same post with the nouns swapped.

Measured across the six drafts and six human posts:

| Post | Catchphrases used | Words |
|---|---|---|
| #67 deliberation-architecture-overhaul | 2/8 | 780 |
| #68 discord-pipeline-bot | 2/8 | 830 |
| #69 multi-issue-build-orchestration | 2/8 | 627 |
| #73 token-spend-measurement | 2/8 | 577 |
| **#74 autonomous-deployment-loop** | **7/8** | 560 |
| **#75 audit-trail-skill** | **6/8** | 610 |
| `guardrails-vs-velocity` (human) | 0/8 | 1381 |
| `building-a-circuit-breaker-across-two-repos` (human) | 0/8 | 1042 |
| `the-500-line-rule` (human) | 1/8 | 1377 |

#74 and #75 fire "Ok. That's new." then "So, now what?" then "But then, I noticed something." then "Cool!" then "My theory is" then "Thanks for reading!" — in that order, under the same `## The Problem` / `## The Investigation` / `## The Solution` / `## Conclusion` headers.

The cause is structural, not a model failure: the "Characteristic phrases to emulate" list is the most quotable part of the guide, and the rejection criteria enforce the *presence* of voice markers with no ceiling. A generator optimising against that rubric produces exactly this. These rules add the missing ceiling, ban the templated header set, correct the length target to match the published corpus (700-1400, not the 400-700 the generator prompt was asking for), and require real artifacts rather than invented pseudo-code in code blocks.

The generator prompt in Ensemble#2543 carries the same rules, so they apply whether the writer reads this file or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)