### PR TITLE
blog: publish the four reviewed AI-generated posts

### DIFF
--- a/data/blog/deliberation-architecture-overhaul.mdx
+++ b/data/blog/deliberation-architecture-overhaul.mdx
@@ -2,7 +2,7 @@
 title: 'Overhauling Deliberation: From Broken Provider Dispatch to Auto-PR Transcripts'
 date: '2026-05-03'
 tags: ['ai', 'automation', 'ductor', 'dev-log']
-draft: true
+draft: false
 aiGenerated: true
 summary: 'A deliberation session silently failed because the health check was hitting the wrong endpoint. Fixing that one bug turned into a five-part architecture overhaul covering provider dispatch, transcript persistence, and orchestrator handoff.'
 authors: ['default']

--- a/data/blog/discord-pipeline-bot.mdx
+++ b/data/blog/discord-pipeline-bot.mdx
@@ -2,7 +2,7 @@
 title: 'The Discord Bot Was the Easy Part'
 date: '2026-05-10'
 tags: ['automation', 'ai', 'ductor']
-draft: true
+draft: false
 aiGenerated: true
 summary: 'I asked an AI deliberation whether to build a Discord bot to replace my 3-minute poll cycle. The deliberation crashed three different ways — and that failure was more useful than the answer would have been.'
 ---

--- a/data/blog/multi-issue-build-orchestration.mdx
+++ b/data/blog/multi-issue-build-orchestration.mdx
@@ -2,7 +2,7 @@
 title: 'Why I Sequenced Multi-Issue Build Orchestration Instead of Parallelizing It Immediately'
 date: '2026-05-17'
 tags: ['automation', 'ai', 'ductor']
-draft: true
+draft: false
 aiGenerated: true
 summary: 'I wanted the Pipeline tab to chew through a chain of planned issues instead of making me click them one by one. The tempting answer was parallel sessions, but the March 23 state lessons made serial mode the right thing to ship first.'
 ---

--- a/data/blog/token-spend-measurement.mdx
+++ b/data/blog/token-spend-measurement.mdx
@@ -2,7 +2,7 @@
 title: 'I Had No Idea What a Pipeline Run Cost. Now I Do.'
 date: '2026-07-12'
 tags: ['automation', 'ai', 'ductor']
-draft: true
+draft: false
 aiGenerated: true
 summary: 'Every cost-reduction experiment I wanted to run — prompt optimization, cheaper model routing, stripped-down prompt variants — was uncalibrated because nothing measured per-run token spend. The fix was a measurement layer, and the load-bearing decision turned out to be the schema, not the capture point.'
 ---


### PR DESCRIPTION
Flips `draft: true` → `draft: false` on the four posts reviewed and edited today. They were merged as drafts (the repo convention for AI-generated posts), so they are in the repo but excluded from production builds — this makes them live.

| Post | Words | Internal links | Catchphrases |
|---|---|---|---|
| token-spend-measurement | 577 | 1 | 2/8 |
| multi-issue-build-orchestration | 636 | 1 | 2/8 |
| deliberation-architecture-overhaul | 795 | 1 | 2/8 |
| discord-pipeline-bot | 831 | 5 | 2/8 |

All four sit at the low end of the human corpus (694–1381 words) — worth knowing, though each was edited and none is padded.

**`aiGenerated: true` is preserved on all four.** That flag is the transparency marker, not a draft gate.

### Fixed before publishing
- `deliberation-architecture-overhaul` — its conclusion was about a "maximize toggle for output panels" that appears nowhere else in the post; replaced with a close that follows from the health-check story it actually tells.
- `multi-issue-build-orchestration` — `/blog/what-is-ecoorchestra` 404s; the real slug is date-prefixed.
- `discord-pipeline-bot` — `<1 day` in the phase table is parsed by MDX v2 as the start of a JSX tag, which is why its Vercel deployment had failed since May.
- Both of the above also had the templated `## The Problem` / `## The Investigation` / `## The Solution` / `## Conclusion` header set replaced with headers naming their own content.

### Validated before flipping
All six required frontmatter fields present, every internal `/blog/...` link resolves to a real post in `data/blog/`, and no MDX v2 JSX hazards remain.

### Not included
`ensemble-vps-rollout` has sat at `draft: true` since April. It predates this review and I have not read it editorially, so it stays a draft — say the word and I will review and flip it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)